### PR TITLE
Fix Wikipedia Current Events RSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 .idea
 .python-version
 
+# Session cache
+to_rss_requests.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "server:app"]
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## To RSS
 
-[![pipeline status](https://travis-ci.org/clokep/to-rss.svg?branch=master)](https://travis-ci.org/clokep/to-rss)
-
 This project aims to provide RSS feeds for platforms that should just provide
 RSS feeds. It supports a few different endpoints.
 

--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ only emails out updates. This provides a way to see those over RSS.
 It is a Flask application that serves RSS feeds generated using
 [FeedGenerator](https://github.com/getpelican/feedgenerator). Generally
 information is pulled using requests and parsed with BeautifulSoup4.
+
+Run the application with `flask run`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ iso8601==1.0.2
 
 # For Patreon.
 selenium==4.2.0
+PyVirtualDisplay==3.0
 
 # For Pottermore.
 Markdown==3.4.3

--- a/to_rss/templates/index.html
+++ b/to_rss/templates/index.html
@@ -83,6 +83,6 @@
 
 <p>
   See a bug? Think another site should be added? Please
-  <a href="https://gitlab.com/clokep/to-rss/issues">make a suggestion</a>!
+  <a href="https://github.com/clokep/to-rss/issues">make a suggestion</a>!
 </p>
 {% endblock %}

--- a/to_rss/wikipedia.py
+++ b/to_rss/wikipedia.py
@@ -19,13 +19,13 @@ def get_current_events_by_date(lookup_date):
     # https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions#.23time with
     # a format of "Y F j". This is awkward because we want the day *not* zero
     # padded, but the month as a string.
-    datestr = f"{lookup_date.year} {lookup_date.strftime('%B')} {lookup_date.day}"
+    datestr = f"{lookup_date.year}_{lookup_date.strftime('%B')}_{lookup_date.day}"
     return "Portal:Current_events/" + datestr
 
 
 def get_article(url):
     """Fetches and returns the article content as a string."""
-    response = get_session().get(url, params={"action": "raw"})
+    response = get_session().get(url, params={"action": "raw"}, headers={'User-agent': 'Current Events to RSS'})
     return response.text
 
 
@@ -39,7 +39,7 @@ def get_articles():
     which then includes the past seven days.
     """
     resolver = mwcomposerfromhell.ArticleResolver(
-        base_url="https://en.wikipedia.org/wiki/"
+        base_url="https://en.m.wikipedia.org/wiki/"
     )
     feed = feedgenerator.Rss201rev2Feed(
         "Wikipedia: Portal: Current events",


### PR DESCRIPTION
Wikipedia recently changed the policy on programmatic access to Wikipedia. Adapted this repo to include the required User Agent string. More details:
  * https://phabricator.wikimedia.org/T400119
  * https://wikitech.wikimedia.org/wiki/Robot_policy

Further small fixes:
  * to-rss.xyz website still pointed to outdated Gitlab repo
  * removed outdated Travis build indicator
  * added instructions to `README.md` how to run the application
  * added session cache file (`to_rss_requests.sqlite`) to `.gitignore`
  * added a missing dependency to `requirements.txt`
  * added a `Dockerfile`