### PR TITLE
Support the new Current events page layout

### DIFF
--- a/tests/test_wikipedia.py
+++ b/tests/test_wikipedia.py
@@ -1,7 +1,44 @@
+import mwparserfromhell
+
 from tests import assert_items_exists
-from to_rss.wikipedia import get_articles
+from to_rss.wikipedia import extract_content, get_articles
+
+# The layout used until mid-2026: the day's news lives in the template's
+# "content" parameter.
+LEGACY_ARTICLE = """{{Current events|year=2026|month=07|day=20|content=
+<!-- All news items below this line -->
+'''Armed conflicts and attacks'''
+*[[Example conflict]]
+<!-- All news items above this line -->}}
+"""
+
+# The layout used since: a "top=yes" template, the news, then a "bottom=yes" one.
+SANDWICH_ARTICLE = """{{Current events|year=2026|month=08|day=2|top=yes}}
+
+<!-- All news items below this line -->
+'''Armed conflicts and attacks'''
+*[[Example conflict]]
+{{Current events|year=2026|month=08|day=2|bottom=yes}}"""
 
 
 def test_current_events():
     result = get_articles()
     assert_items_exists(result)
+
+
+def test_extract_content_legacy():
+    content = extract_content(mwparserfromhell.parse(LEGACY_ARTICLE))
+    assert "Armed conflicts and attacks" in str(content)
+    assert "[[Example conflict]]" in str(content)
+
+
+def test_extract_content_sandwich():
+    content = extract_content(mwparserfromhell.parse(SANDWICH_ARTICLE))
+    assert "Armed conflicts and attacks" in str(content)
+    assert "[[Example conflict]]" in str(content)
+    # The wrapping templates themselves must not leak into the output.
+    assert "Current events" not in str(content)
+
+
+def test_extract_content_missing_template():
+    assert extract_content(mwparserfromhell.parse("''Nothing to see here.''")) is None

--- a/to_rss/wikipedia.py
+++ b/to_rss/wikipedia.py
@@ -33,6 +33,36 @@ def get_article(url: str) -> str:
     return response.text
 
 
+def extract_content(wikicode: mwparserfromhell.wikicode.Wikicode):
+    """
+    Returns a day's news items as Wikicode, or None if they can't be found.
+
+    Current event pages come in two layouts. Historically a single
+    ``{{Current events}}`` template carried the whole day in its ``content``
+    parameter. Newer pages instead sandwich the news between two copies of the
+    template, marked ``top=yes`` and ``bottom=yes``, leaving the items in the
+    article body between them.
+    """
+    templates = [
+        template
+        for template in wikicode.filter_templates(recursive=False)
+        if template.name == "Current events"
+    ]
+    if not templates:
+        return None
+
+    # Legacy layout: the news is a parameter of the template.
+    for template in templates:
+        if template.has("content"):
+            return template.get("content").value
+
+    # Current layout: the news is whatever follows the opening template, up to
+    # the closing one (dropped along with anything after it).
+    start = wikicode.index(templates[0]) + 1
+    end = wikicode.index(templates[-1]) if len(templates) > 1 else len(wikicode.nodes)
+    return mwparserfromhell.wikicode.Wikicode(wikicode.nodes[start:end])
+
+
 def get_articles() -> str:
     """
     Returns a map of dates to a list of current events on that date.
@@ -71,32 +101,27 @@ def get_articles() -> str:
 
         with start_span(op="wiki-to-html", name="Convert " + url):
             # Current event pages have a top-level template.
-            for template in wikicode.ifilter_templates():
-                if template.name == "Current events":
-                    content = template.get("content").value
-
-                    try:
-                        # Convert the Wikicode to HTML.
-                        result = composer.compose(content)
-                    except mwcomposerfromhell.HtmlComposingError:
-                        logger.error("Unable to render article from: %s", day)
-                        continue
-
-                    # Add the results to the RSS feed.
-                    feed.add_item(
-                        title=f"Current events: {day}",
-                        link=url,
-                        description=result,
-                        pubdate=datetime(*day.timetuple()[:3]),
-                    )
-
-                    # Stop processing this article.
-                    break
-
-            else:
+            content = extract_content(wikicode)
+            if content is None:
                 logger.error(
                     f"'Current events' template not found in article for {day}"
                 )
+                continue
+
+            try:
+                # Convert the Wikicode to HTML.
+                result = composer.compose(content)
+            except mwcomposerfromhell.HtmlComposingError:
+                logger.error("Unable to render article from: %s", day)
+                continue
+
+            # Add the results to the RSS feed.
+            feed.add_item(
+                title=f"Current events: {day}",
+                link=url,
+                description=result,
+                pubdate=datetime(*day.timetuple()[:3]),
+            )
 
     if len(feed.items) == 0:
         logger.error("Created empty feed for Wikipedia current events")


### PR DESCRIPTION
Wikipedia has started rewriting Portal:Current_events daily pages so the day's news is no longer stored in the "content" parameter of a single {{Current events}} template. The news is now placed in the article body, between a "top=yes" copy of the template and a "bottom=yes" one.

Requesting a day in the new layout raised ValueError from Template.get("content"), which surfaced as a 500 for the whole feed: one converted page is enough to break every other day's items too.

Read the news from either layout, preferring "content" when present, and return None instead of raising when no template matches. Both layouts are live on Wikipedia right now, so both need to keep working.